### PR TITLE
Remove Wallpanel APK

### DIFF
--- a/WALLPANEL.md
+++ b/WALLPANEL.md
@@ -1,3 +1,5 @@
+You can't take my APK file that belongs to my open source project and use it in your own project.  You must refer back to my project because I own that APK and the code and you have to credit my project.   Please remove the WallPanel apk from your project. 
+
 ## WALLPANEL
 
 1. **[Fire-OS](#fire-os)**


### PR DESCRIPTION
I am the original owner of all APK files and code associated with Wallpanel, you cannot host and distribute the APK as your own.  You must reference my project pages as outline in the copyright notices.   You are violating the copyright.   Remove my apk from your site now. 